### PR TITLE
fixed listmembers printing bug

### DIFF
--- a/src/commands/listmembers.js
+++ b/src/commands/listmembers.js
@@ -67,7 +67,7 @@ const getMembers = ctx => {
           ctx.members = members;
           return ctx;
         } else {
-          Logger.warn(`\nno members are assigned to ${team}\n`);
+          Logger.warn(`\nno members are assigned to ${team.name}\n`);
           process.exit(0);
         }
       })


### PR DESCRIPTION
when no members were found for a team when running listmembers, message
printing "no members are assigned to [object Object]"...fixed so prints
team name instead of "[object Object]"

Closes #19 